### PR TITLE
Add new 6 acquirers, 5 consequences and 3 lua functions

### DIFF
--- a/ModularSkillScripts/Acquirer/AcquirerDidUseSkillLastTurn.cs
+++ b/ModularSkillScripts/Acquirer/AcquirerDidUseSkillLastTurn.cs
@@ -1,0 +1,14 @@
+using ModularSkillScripts;
+
+namespace ModularSkillScripts.Acquirer;
+
+public class AcquirerDidUseSkillLastTurn : IModularAcquirer
+{
+    public int ExecuteAcquirer(ModularSA modular, string section, string circledSection, string[] circles)
+    {
+        BattleUnitModel target = modular.GetTargetModel(circles[0]);
+        if (target == null) return -1;
+        int skillId = modular.GetNumFromParamString(circles[1]);
+        return target.DidActionPrevTurn(skillId) ? 1 : 0;
+    }
+}

--- a/ModularSkillScripts/Acquirer/AcquirerGetCurrentPower.cs
+++ b/ModularSkillScripts/Acquirer/AcquirerGetCurrentPower.cs
@@ -1,0 +1,15 @@
+using ModularSkillScripts;
+
+namespace ModularSkillScripts.Acquirer
+{
+    public class AcquirerGetCurrentPower : IModularAcquirer
+    {
+        public int ExecuteAcquirer(ModularSA modular, string section, string circledSection, string[] circles)
+        {
+            BattleActionModel action = modular.modsa_selfAction;
+            if (circles[0] != "Self") action = modular.modsa_oppoAction;
+            if (action == null) return -1;
+            return action.GetFinalSkillPowerResult(modular.battleTiming);
+        }
+    }
+}

--- a/ModularSkillScripts/Acquirer/AcquirerGetDefaultMaxHp.cs
+++ b/ModularSkillScripts/Acquirer/AcquirerGetDefaultMaxHp.cs
@@ -1,0 +1,13 @@
+using ModularSkillScripts;
+
+namespace ModularSkillScripts.Acquirer
+{
+    public class AcquirerGetDefaultMaxHp : IModularAcquirer
+    {
+        public int ExecuteAcquirer(ModularSA modular, string section, string circledSection, string[] circles)
+        {
+            BattleUnitModel target = modular.GetTargetModel(circles[0]);
+            return target.UnitDataModel.ClassInfo.hp.defaultStat;
+        }
+    }
+}

--- a/ModularSkillScripts/Acquirer/AcquirerGetHpIncrementByLevel.cs
+++ b/ModularSkillScripts/Acquirer/AcquirerGetHpIncrementByLevel.cs
@@ -1,0 +1,14 @@
+using ModularSkillScripts;
+using System;
+
+namespace ModularSkillScripts.Acquirer
+{
+    public class AcquirerGetHpIncrementByLevel : IModularAcquirer
+    {
+        public int ExecuteAcquirer(ModularSA modular, string section, string circledSection, string[] circles)
+        {
+            BattleUnitModel target = modular.GetTargetModel(circles[0]);
+            return (int) Math.Floor(target.UnitDataModel.ClassInfo.hp.incrementByLevel * 100);
+        }
+    }
+}

--- a/ModularSkillScripts/Acquirer/AcquirerGetOppoSkillId.cs
+++ b/ModularSkillScripts/Acquirer/AcquirerGetOppoSkillId.cs
@@ -1,0 +1,12 @@
+using ModularSkillScripts;
+
+namespace ModularSkillScripts.Acquirer;
+
+public class AcquirerGetOpponentSkillId : IModularAcquirer
+{
+	public int ExecuteAcquirer(ModularSA modular, string section, string circledSection, string[] circles)
+	{
+		if (modular.modsa_oppoAction != null) return modular.modsa_oppoAction.Skill.GetID();
+		return 0;
+	}
+}

--- a/ModularSkillScripts/Acquirer/AcquirerIsActionable.cs
+++ b/ModularSkillScripts/Acquirer/AcquirerIsActionable.cs
@@ -1,0 +1,13 @@
+using ModularSkillScripts;
+
+namespace ModularSkillScripts.Acquirer;
+
+public class AcquirerIsActionable : IModularAcquirer
+{
+    public int ExecuteAcquirer(ModularSA modular, string section, string circledSection, string[] circles)
+    {
+        BattleUnitModel target = modular.GetTargetModel(circles[0]);
+        if (target == null) return -1;
+        return target.IsActionable() ? 1 : 0;
+    }
+}

--- a/ModularSkillScripts/Consequence/ConsequenceChangeSp.cs
+++ b/ModularSkillScripts/Consequence/ConsequenceChangeSp.cs
@@ -1,0 +1,17 @@
+using ModularSkillScripts;
+
+namespace ModularSkillScripts.Consequence;
+
+public class ConsequenceChangeSp : IModularConsequence
+{
+    public void ExecuteConsequence(ModularSA modular, string section, string circledSection, string[] circles)
+    {
+        Il2CppSystem.Collections.Generic.List<BattleUnitModel> targetList = modular.GetTargetModelList(circles[0]);
+        if (targetList.Count < 1) return;
+        int newMp = modular.GetNumFromParamString(circles[1]);
+        foreach(BattleUnitModel target in targetList)
+        {
+            target.ChangeMp(newMp);
+        }
+    }
+}

--- a/ModularSkillScripts/Consequence/ConsequenceRemoveCoin.cs
+++ b/ModularSkillScripts/Consequence/ConsequenceRemoveCoin.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using ModularSkillScripts;
+
+namespace ModularSkillScripts.Consequence;
+
+public class ConsequenceRemoveCoin : IModularConsequence
+{
+	public void ExecuteConsequence(ModularSA modular, string section, string circledSection, string[] circles)
+	{
+		SkillModel skill = (circles[0] == "Self") ? modular.modsa_skillModel : modular.modsa_oppoAction._skill;
+		foreach (string circle in circles.Skip(1))
+		{
+			int idx = modular.GetNumFromParamString(circle);
+			if (idx < 0)
+			{
+				skill.RemoveCoinModelFromListByIndex(modular.modsa_coinModel.GetOriginCoinIndex());
+				continue;
+			}
+
+			idx = Math.Min(idx, skill.CoinList.Count - 1);
+			skill.RemoveCoinModelFromListByIndex(idx);
+		}
+	}
+}

--- a/ModularSkillScripts/Consequence/ConsequenceSetLevel.cs
+++ b/ModularSkillScripts/Consequence/ConsequenceSetLevel.cs
@@ -1,0 +1,19 @@
+using ModularSkillScripts;
+using System;
+
+namespace ModularSkillScripts.Consequence
+{
+    public class ConsequenceSetLevel : IModularConsequence
+    {
+        public void ExecuteConsequence(ModularSA modular, string section, string circledSection, string[] circles)
+        {
+            Il2CppSystem.Collections.Generic.List<BattleUnitModel> unitList = modular.GetTargetModelList(circles[0]);
+            if (unitList.Count < 1) return;
+            int newLevel = modular.GetNumFromParamString(circles[1]);
+            foreach (BattleUnitModel unit in unitList)
+            {
+                unit.UnitDataModel._level = newLevel;
+            }
+        }
+    }
+}

--- a/ModularSkillScripts/Consequence/ConsequenceSetMaxHp.cs
+++ b/ModularSkillScripts/Consequence/ConsequenceSetMaxHp.cs
@@ -1,0 +1,19 @@
+using ModularSkillScripts;
+using System;
+
+namespace ModularSkillScripts.Consequence
+{
+    public class ConsequenceSetMaxHp : IModularConsequence
+    {
+        public void ExecuteConsequence(ModularSA modular, string section, string circledSection, string[] circles)
+        {
+            Il2CppSystem.Collections.Generic.List<BattleUnitModel> unitList = modular.GetTargetModelList(circles[0]);
+            if (unitList.Count < 1) return;
+            int newMaxHp = modular.GetNumFromParamString(circles[1]);
+            foreach (BattleUnitModel unit in unitList)
+            {
+                unit.UnitDataModel._maxHp = newMaxHp;
+            }
+        }
+    }
+}

--- a/ModularSkillScripts/LuaFunction/LuaFunctionGetAppearanceID.cs
+++ b/ModularSkillScripts/LuaFunction/LuaFunctionGetAppearanceID.cs
@@ -1,0 +1,19 @@
+using ModularSkillScripts;
+using ModularSkillScripts.LuaFunction;
+using Lua;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace ModularSkillScripts.LuaFunction;
+
+public class LuaFunctionGetAppearanceID : IModularLuaFunction
+{
+    public ValueTask<int> ExecuteLuaFunction(ModularSA modular, LuaFunctionExecutionContext context, System.Span<LuaValue> buffer, CancellationToken ct)
+    {
+        BattleUnitModel target = modular.GetTargetModel(context.GetArgument(0).Read<string>());
+        if (target == null) return ValueTask.FromResult(0);
+
+        buffer[0] = target.GetAppearanceID();
+        return ValueTask.FromResult(1);
+    }
+}

--- a/ModularSkillScripts/LuaFunction/LuaFunctionGetCurrentMapID.cs
+++ b/ModularSkillScripts/LuaFunction/LuaFunctionGetCurrentMapID.cs
@@ -1,0 +1,17 @@
+using ModularSkillScripts;
+using ModularSkillScripts.LuaFunction;
+using System.Threading;
+using System.Threading.Tasks;
+using Lua;
+
+namespace ModularSkillScripts.LuaFunction;
+
+public class LuaFunctionGetCurrentMapID : IModularLuaFunction
+{
+    public ValueTask<int> ExecuteLuaFunction(ModularSA modular, LuaFunctionExecutionContext context, System.Span<LuaValue> buffer, CancellationToken ct)
+    {
+        buffer[0] = BattleMapManager.Instance._mapObject._currentMap.GetMapID();
+
+        return ValueTask.FromResult(1);
+    }
+}

--- a/ModularSkillScripts/LuaFunction/LuaFunctionListBreakValues.cs
+++ b/ModularSkillScripts/LuaFunction/LuaFunctionListBreakValues.cs
@@ -1,0 +1,29 @@
+using ModularSkillScripts;
+using ModularSkillScripts.LuaFunction;
+using Lua;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace ModularSkillScripts.LuaFunction;
+
+public class LuaFunctionListBreakSectionValue : IModularLuaFunction
+{
+    public ValueTask<int> ExecuteLuaFunction(ModularSA modular, LuaFunctionExecutionContext context, System.Span<LuaValue> buffer, CancellationToken ct)
+    {
+        BattleUnitModel target = modular.GetTargetModel(context.GetArgument(0).Read<string>());
+        if (target == null) return ValueTask.FromResult(0);
+
+        bool isActiveOnly = context.GetArgument(1).Read<bool>();
+        Il2CppSystem.Collections.Generic.List<int> breakSectionValue = target.GetBreakSectionValueList(isActiveOnly);
+
+        var table = new LuaTable();
+
+        for (int i = 0; i < breakSectionValue.Count; i++)
+        {
+            table[i + 1] = breakSectionValue[i];
+        }
+
+        buffer[0] = table;
+        return ValueTask.FromResult(1);
+    }
+}

--- a/ModularSkillScripts/MainClass.cs
+++ b/ModularSkillScripts/MainClass.cs
@@ -205,6 +205,11 @@ public class MainClass : BasePlugin
 		consequenceDict["buffcategory"] = new ConsequenceBuffCategory();
 		consequenceDict["destroybuff"] = new ConsequenceDestroyBuff();
 		consequenceDict["setdmgtaken"] = new ConsequenceSetChangeDamageTaken();
+		consequenceDict["lbreak"] = new ConsequenceBreak();
+		consequenceDict["removecoin"] = new ConsequenceRemoveCoin();
+		consequenceDict["setlevel"] = new ConsequenceSetLevel();
+		consequenceDict["setmaxhp"] = new ConsequenceSetMaxHp();
+		consequenceDict["changesp"] = new ConsequenceChangeSp();
 		//consequenceDict["sinbuffmult"] = new ConsequenceSinBuffMult();
 
 		// legacy consequences
@@ -334,8 +339,12 @@ public class MainClass : BasePlugin
 		acquirerDict["useddefaction"] = new AcquirerUsedDefenseActionThisTurn();
 		acquirerDict["unitfaction"] = new AcquirerUnitFaction();
 		acquirerDict["chainstatus"] = new AcquirerChainStatus();
-
-
+		acquirerDict["getopposkillid"] = new AcquirerGetOpponentSkillId();
+		acquirerDict["getcurrentpower"] = new AcquirerGetCurrentPower();
+		acquirerDict["getdefaultmaxhp"] = new AcquirerGetDefaultMaxHp();
+		acquirerDict["gethpincrement"] = new AcquirerGetHpIncrementByLevel();
+		acquirerDict["diduseskilllastturn"] = new AcquirerDidUseSkillLastTurn();
+		acquirerDict["isactionable"] = new AcquirerIsActionable();
 
 		// Register Lua functions
 		luaFunctionDict["clearvalues"] = new ModularSkillScripts.LuaFunction.LuaFunctionClearValues();
@@ -353,6 +362,9 @@ public class MainClass : BasePlugin
 		luaFunctionDict["clearallgdata"] = new ModularSkillScripts.LuaFunction.LuaFunctionClearAllGData();
 		luaFunctionDict["gbkeyword"] = new ModularSkillScripts.LuaFunction.LuaFunctionGainBuffKeyword();
 		luaFunctionDict["addresource"] = new ModularSkillScripts.LuaFunction.LuaFunctionAddResource();
+		luaFunctionDict["getcurrentmapid"] = new ModularSkillScripts.LuaFunction.LuaFunctionGetCurrentMapID();
+		luaFunctionDict["getappearanceid"] = new ModularSkillScripts.LuaFunction.LuaFunctionGetAppearanceID();
+		luaFunctionDict["listbreakvalues"] = new ModularSkillScripts.LuaFunction.LuaFunctionListBreakSectionValue();
 	}
 
 	public static System.Collections.Generic.List<BattleUnitModel> ShuffleUnits(

--- a/ModularSkillScripts/Patches/OnGainBuffPatches.cs
+++ b/ModularSkillScripts/Patches/OnGainBuffPatches.cs
@@ -37,7 +37,7 @@ internal class OnGainBuffPatches
 					modpa.gainbuff_turn = turn;
 					modpa.gainbuff_activeRound = activeRound;
 					modpa.gainbuff_source = srcType;
-					modpa.Enact(__instance, null, null, null, actevent, timing);
+					modpa.Enact(__instance, null, null, actionOrNull, actevent, timing);
 				}
 			}
 
@@ -65,7 +65,7 @@ internal class OnGainBuffPatches
 					modpa.gainbuff_turn = turn;
 					modpa.gainbuff_activeRound = activeRound;
 					modpa.gainbuff_source = srcType;
-					modpa.Enact(__instance, null, null, null, actevent, timing);
+					modpa.Enact(__instance, null, null, actionOrNull, actevent, timing);
 				}
 			}
 		}


### PR DESCRIPTION
- Acquirers: getopposkillid, getcurrentpower, getdefaultmaxhp, gethpincrement, isactionable, diduseskilllastturn (is didusedskillprevturn in MT's Custom Scripts)
- Consequences: removecoin, setlevel, setmaxhp, changesp, lbreak (same as 'break' but works in .lua scripts)
- Lua Functions: getcurrentmapid, getappearanceid, listbreakvalues

https://rentry.co/mtcustomscripts