### PR TITLE
Implement AtkWeight

### DIFF
--- a/ModularSkillScripts/Consequence/ConsequenceAtkWeight.cs
+++ b/ModularSkillScripts/Consequence/ConsequenceAtkWeight.cs
@@ -1,0 +1,9 @@
+namespace ModularSkillScripts.Consequence;
+
+public class ConsequenceAtkWeight : IModularConsequence
+{
+	public void ExecuteConsequence(ModularSA modular, string section, string circledSection, string[] circles)
+	{
+		modular.atkWeightAdder = modular.GetNumFromParamString(circledSection);
+	}
+}

--- a/ModularSkillScripts/MainClass.cs
+++ b/ModularSkillScripts/MainClass.cs
@@ -223,6 +223,7 @@ public class MainClass : BasePlugin
 		consequenceDict["bonusdmgbybuff"] = new ConsequenceBonusDmgByBuff();
 		//consequenceDict["sinbuffmult"] = new ConsequenceSinBuffMult();
 		//consequenceDict["changeatktype"] = new ConsequenceChangeAtkType();
+		consequenceDict["atkweight"] = new ConsequenceAtkWeight();
 
 		// legacy consequences
 		consequenceDict["mpdmg"] = new ConsequenceMpDmg();

--- a/ModularSkillScripts/ModularScripts.cs
+++ b/ModularSkillScripts/ModularScripts.cs
@@ -243,7 +243,7 @@ public class ModularSA : Il2CppSystem.Object
 		parryingResultAdder = 0;
 		atkDmgAdder = 0;
 		atkMultAdder = 0;
-		//atkWeightAdder = 0;
+		atkWeightAdder = 0;
 		critAdder = 0;
 	}
 	public int coinScaleAdder = 0;
@@ -252,7 +252,7 @@ public class ModularSA : Il2CppSystem.Object
 	public int parryingResultAdder = 0;
 	public int atkDmgAdder = 0;
 	public int atkMultAdder = 0;
-	//public int atkWeightAdder = 0;
+	public int atkWeightAdder = 0;
 	public int slotAdder = 0;
 	public int critAdder = 0;
 	public ATK_BEHAVIOUR atktype = ATK_BEHAVIOUR.NONE;

--- a/ModularSkillScripts/Patches/SkillScriptInitPatch.cs
+++ b/ModularSkillScripts/Patches/SkillScriptInitPatch.cs
@@ -1628,8 +1628,6 @@ public class CoroutineRunner : UnityEngine.MonoBehaviour
 				__result += modpaList[i].atkWeightAdder;
 			}
 		}
-
-		if (__result < 0) __result = 0;
 	}
 
 	//[HarmonyPatch(typeof(SkillModel), nameof(SkillModel.GetAttackWeight))]

--- a/ModularSkillScripts/Patches/SkillScriptInitPatch.cs
+++ b/ModularSkillScripts/Patches/SkillScriptInitPatch.cs
@@ -1582,12 +1582,55 @@ public class CoroutineRunner : UnityEngine.MonoBehaviour
 		}
 	}
 
-	//[HarmonyPatch(typeof(BattleUnitModel), nameof(BattleUnitModel.GetAttackWeightAdder))]
-	//[HarmonyPostfix]
-	//private static void Postfix_BattleUnitModel_GetAttackWeightAdder(BattleActionModel action, int __result)
-	//{
-	//	__result += 5;
-	//}
+	[HarmonyPatch(typeof(BattleUnitModel), nameof(BattleUnitModel.GetAttackWeightAdder))]
+	[HarmonyPostfix]
+	private static void Postfix_BattleUnitModel_GetAttackWeightAdder(BattleActionModel action, ref int __result, BattleUnitModel __instance)
+	{
+		long skillmodel_intlong = action.Skill.Pointer.ToInt64();
+		if (modsaDict.ContainsKey(skillmodel_intlong))
+		{
+			foreach (ModularSA modsa in modsaDict[skillmodel_intlong])
+			{
+				__result += modsa.atkWeightAdder;
+			}
+		}
+
+		foreach (PassiveModel passiveModel in __instance._passiveDetail.PassiveList.CopyList())
+		{
+			foreach (ModularSA modpa in GetAllModpaFromPasmodel(passiveModel))
+			{
+				__result += modpa.atkWeightAdder;
+			}
+		}
+
+		foreach (BuffModel buffModel in __instance._buffDetail.GetActivatedBuffModelAll())
+		{
+			foreach (ModularSA modba in GetAllModbaFromBuffModel(buffModel))
+			{
+				__result += modba.atkWeightAdder;
+			}
+		}
+
+		foreach (PassiveModel passiveModel in __instance._passiveDetail.EgoPassiveList.CopyList())
+		{
+			foreach (ModularSA modpa in GetAllModpaFromPasmodel(passiveModel, false))
+			{
+				__result += modpa.atkWeightAdder;
+			}
+		}
+
+		SupportPasPatch.SupportPassiveInit(modpaDict);
+		foreach (SupporterPassiveModel supportPassive in MainClass.activeSupporterPassiveList)
+		{
+			List<ModularSA> modpaList = GetAllModpaFromPasmodelSupport(supportPassive);
+			for (int i = 0; i < modpaList.Count; i++)
+			{
+				__result += modpaList[i].atkWeightAdder;
+			}
+		}
+
+		if (__result < 0) __result = 0;
+	}
 
 	//[HarmonyPatch(typeof(SkillModel), nameof(SkillModel.GetAttackWeight))]
 	//[HarmonyPostfix]
@@ -2830,5 +2873,5 @@ public class CoroutineRunner : UnityEngine.MonoBehaviour
 			}
 		}
 	}
-	
+
 }


### PR DESCRIPTION
Grabs the unused `atkweightadder` and implements it into `BattleUnitModel.GetAttackWeightAdder`
From what I understand from my own observations, adding attack weight and selecting the targets are both seperate events. One does not get called upon just because the other is called. So this doesn't really work on timings like `WhenUse`, but it does work on timings like `RoundStart`. 